### PR TITLE
Feat: Variant and default variant support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tw-classed",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "A Stitches & Styled-Components inspired library to create reusable Tailwind react components",
   "type": "module",
   "main": "dist/index.js",

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,38 @@ const Grid = classed(
 export default Grid;
 ```
 
+##### Using Variants
+
+Insert an object as an argument to `classed` to define variants and defaultVariants for the component.
+Later use the key i.e color prop to set the variant.
+
+```tsx
+// Button.tsx
+import classed from "tw-classed";
+
+const Button = classed("button", "p-4 rounded-md", {
+  variants: {
+    color: {
+      blue: "bg-blue-500 text-white",
+      primary: "bg-indigo-500 text-white",
+    },
+  },
+  defaultVariants: {
+    color: "blue",
+  },
+});
+
+const MyApp = () => {
+  return (
+    <>
+      <Button color="primary">Im the primary color</Button>
+      <Button color="blue">Im the blue color</Button>
+      <Button>Im the default color (blue)</Button>
+    </>
+  );
+};
+```
+
 ##### Using the `as` prop
 
 This allows for TypeScript intellisense to infer props based on the `as` prop.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,27 +1,51 @@
 import type * as Polymorphic from "@radix-ui/react-polymorphic";
-import { forwardRef } from "react";
-import { classedParser } from "./parser.js";
-import type { ClassNames, TwModifyer, Modifyer, Breakpoints } from "./types.js";
+import { forwardRef, useMemo } from "react";
+import { composeParser } from "./parser.js";
+import type {
+  ClassNames,
+  TwModifyer,
+  Modifyer,
+  Breakpoints,
+  Variants,
+  ClassNamesAndVariant,
+  VariantProps,
+} from "./types.js";
 
-function classed<T extends keyof JSX.IntrinsicElements>(
+function classed<T extends keyof JSX.IntrinsicElements, V extends Variants>(
   elementType: T,
-  ...classNames: ClassNames[]
+  ...classNames: ClassNamesAndVariant<V>[]
 ) {
-  const className = classedParser(classNames);
+  // const className = classedParser(classNames);
+
+  const { className, variants, defaultVariants } = composeParser(classNames);
 
   const ClassedComponent = forwardRef(
     ({ as, className: cName, ...props }: any, forwardedRef: any) => {
       const Component = as || elementType;
 
+      // Map props variant to className
+      const variantClassNames = useMemo(() => {
+        return Object.keys(variants).reduce((acc, value) => {
+          const vInProps = props[value] || defaultVariants?.[value]; // Prefer props over defaultVariants
+          if (!vInProps) return acc; // Skip if no variant in props
+          const className = variants[value][vInProps as string]; // Get className from variant
+          return acc.concat(" " + className); // Add className to acc
+        }, "");
+      }, [variants]);
+
       return (
         <Component
-          className={className + (cName ? " " + cName : "")}
+          className={
+            className +
+            (cName ? " " + cName : "") +
+            (variantClassNames ? " " + variantClassNames : "")
+          }
           {...props}
           ref={forwardedRef}
         />
       );
     }
-  ) as Polymorphic.ForwardRefComponent<T>;
+  ) as Polymorphic.ForwardRefComponent<T, VariantProps<V>>;
 
   ClassedComponent.displayName = `TwComponent(${elementType})`;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,3 +1,42 @@
-import { ClassNames } from "./types.js";
+import {
+  ClassNames,
+  ClassNamesAndVariant,
+  VariantConfig,
+  Variants,
+} from "./types.js";
 
 export const classedParser = (classNames: ClassNames[]) => classNames.join(" ");
+
+export const composeParser = <T extends Variants>(
+  classNames: ClassNamesAndVariant<T>[]
+) => {
+  let stringClassNames = [];
+  let variantObj = {} as T;
+  let defaultVariants = {} as Partial<VariantConfig<T>["defaultVariants"]>;
+  for (const className of classNames) {
+    if (typeof className === "string") {
+      stringClassNames.push(className);
+      continue;
+    }
+
+    if (className.variants) {
+      variantObj = {
+        ...variantObj,
+        ...className.variants,
+      };
+    }
+
+    if (className.defaultVariants) {
+      defaultVariants = {
+        ...defaultVariants,
+        ...className.defaultVariants,
+      };
+    }
+  }
+
+  return {
+    className: classedParser(stringClassNames),
+    variants: variantObj,
+    defaultVariants,
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,3 +5,21 @@ export type TwModifyer =
   | `${Breakpoints}:${Modifyer}:`;
 
 export type ClassNames = string;
+
+export type Variants = Record<string, Record<string, string>>;
+
+export type VariantConfig<V extends Variants> = {
+  variants?: V;
+  className?: ClassNames;
+  defaultVariants?: Partial<{
+    [K in keyof V]: keyof V[K];
+  }>;
+};
+
+export type ClassNamesAndVariant<V extends Variants> =
+  | string
+  | VariantConfig<V>;
+
+export type VariantProps<V extends Variants> = Partial<
+  Record<keyof V, keyof V[keyof V]>
+>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,8 @@ export type TwModifyer =
 
 export type ClassNames = string;
 
-export type Variants = Record<string, Record<string, string>>;
+export type Variant = Record<string, string>;
+export type Variants = Record<string, Variant>;
 
 export type VariantConfig<V extends Variants> = {
   variants?: V;

--- a/test/classed.spec.tsx
+++ b/test/classed.spec.tsx
@@ -46,3 +46,71 @@ describe("Classed", () => {
     expect(screen.getByTestId("anchor")).toBeInstanceOf(HTMLAnchorElement);
   });
 });
+
+describe("Classed with Variants", () => {
+  it("Should render dom element with classed classNames and class", () => {
+    const Button = classed("button", {
+      variants: {
+        color: {
+          blue: "bg-blue-100",
+        },
+      },
+    });
+
+    render(<Button color="blue" className="test" data-testid="btn" />);
+
+    expect(screen.getByTestId("btn")).toHaveClass("bg-blue-100");
+  });
+
+  it("Should not render any variant if no variant is passed", () => {
+    const Button = classed("button", {
+      variants: {
+        color: {
+          blue: "bg-blue-100",
+        },
+      },
+    });
+
+    render(<Button className="test" data-testid="btn" />);
+
+    expect(screen.getByTestId("btn")).not.toHaveClass("bg-blue-100");
+  });
+
+  it("Should render dom element with correct default variant", () => {
+    const Button = classed("button", {
+      variants: {
+        color: {
+          blue: "bg-blue-100",
+        },
+      },
+
+      defaultVariants: {
+        color: "blue",
+      },
+    });
+
+    render(<Button data-testid="btn" />);
+
+    expect(screen.getByTestId("btn")).toHaveClass("bg-blue-100");
+  });
+
+  it("Should prefer props over defaultVariants", () => {
+    const Button = classed("button", {
+      variants: {
+        color: {
+          blue: "bg-blue-100",
+          red: "bg-red-100",
+        },
+      },
+
+      defaultVariants: {
+        color: "red",
+      },
+    });
+
+    render(<Button color="blue" data-testid="btn" />);
+
+    expect(screen.getByTestId("btn")).toHaveClass("bg-blue-100");
+    expect(screen.getByTestId("btn")).not.toHaveClass("bg-red-100");
+  });
+});


### PR DESCRIPTION
This pull request adds support for Stitches.js inspired variants to define classNames.

The `classed` method now supports adding an object as follows:
```ts
const Component = classed("div", {
  variants: {
    color:  {
      blue: "bg-blue-500"
    }
  },
  defaultVariants: {
    color: "blue" // Optional
  }
  className: "px-4 py-2" // Also optional,
})
```

Add props component by

```tsx
<Component color="blue" />
```