### PR TITLE
fix(react): removed use-client directive

### DIFF
--- a/.changeset/strong-ties-change.md
+++ b/.changeset/strong-ties-change.md
@@ -1,0 +1,5 @@
+---
+"@tw-classed/react": patch
+---
+
+Removed use-client directive from ESM

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "dev": "bunchee ./index.ts --watch",
-    "build": "bunchee ./index.ts && npm run rsc-compat",
+    "build": "bunchee ./index.ts",
     "rsc-compat": "node ./.task/rsc-compat.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { forwardRef, useMemo } from "react";
 import {
   parseClassNames,


### PR DESCRIPTION
Removes the use-client directive as webpack cannot import ESM using this

fixes #14