### PR TITLE
Fix numeric variants

### DIFF
--- a/.changeset/old-chairs-boil.md
+++ b/.changeset/old-chairs-boil.md
@@ -1,0 +1,7 @@
+---
+"docs": patch
+"@tw-classed/core": patch
+"@tw-classed/react": patch
+---
+
+Fix numeric variants

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "docs": "2.0.5",
+    "@tw-classed/core": "1.2.2",
+    "@tw-classed/react": "1.2.2"
+  },
+  "changesets": []
+}

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -90,8 +90,12 @@ export const getVariantSelector = <TVariants extends Variants>(
     variantSelector = variantValue;
   } else if (typeof (variantValue as unknown as boolean) === "boolean") {
     variantSelector = variantValue!.toString();
+  } else if (typeof (variantValue as unknown as number) === "number") {
+    variantSelector = variantValue!.toString();
   } else {
-    variantSelector = defaultVariants?.[variantKey] as string | undefined;
+    variantSelector = defaultVariants?.[variantKey]?.toString() as
+      | string
+      | undefined;
   }
 
   return variantSelector;
@@ -118,6 +122,7 @@ export const mapPropsToVariantClass = <
     const variantSelector = getVariantSelector(variantKey, props, {
       defaultVariants,
     });
+
     if (!variantSelector) return acc;
     shouldDeleteProps && matchedKeys.push(variantKey);
     const variantClassName = variants[variantKey][variantSelector];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,9 +35,7 @@ export type ClassedProducer<V extends Variants = {}> = ((
 export type InferVariantProps<V extends Variants | undefined = undefined> =
   V extends Variants
     ? Partial<{
-        [K in keyof V]: V[K] extends BooleanVariant
-          ? boolean
-          : keyof V[K] | undefined;
+        [K in keyof V]: Util.Widen<keyof V[K]>;
       }>
     : {};
 
@@ -98,7 +96,9 @@ export interface ClassedCoreFunctionType {
             variants?: Variants;
             defaultVariants?: "variants" extends keyof Composers[K]
               ? {
-                  [Name in keyof Composers[K]["variants"]]?: keyof Composers[K]["variants"][Name];
+                  [Name in keyof Composers[K]["variants"]]?: Util.Widen<
+                    keyof Composers[K]["variants"][Name]
+                  >;
                 }
               : never;
             compoundVariants?: (("variants" extends keyof Composers[K]

--- a/packages/core/test/core.spec.ts
+++ b/packages/core/test/core.spec.ts
@@ -69,6 +69,37 @@ describe("Core functionality", () => {
 
     expect(button()).toBe("bg-blue-100 text-md");
   });
+
+  it("Should handle numerical variants", () => {
+    const button = classed("bg-blue-100", {
+      variants: {
+        size: {
+          1: "text-sm",
+          2: "text-md",
+          "3": "text-lg",
+        },
+      },
+    });
+
+    const button2 = classed("bg-blue-100", {
+      variants: {
+        size: {
+          1: "text-sm",
+          2: "text-md",
+          3: "text-lg",
+        },
+      },
+      defaultVariants: {
+        size: 3,
+      },
+    });
+
+    expect(button({ size: 1 })).toBe("bg-blue-100 text-sm");
+
+    expect(button({ size: "3" })).toBe("bg-blue-100 text-lg");
+
+    expect(button2()).toBe("bg-blue-100 text-lg");
+  });
 });
 
 describe("Composition", () => {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -69,7 +69,9 @@ export interface ClassedFunctionType {
             variants?: Variants;
             defaultVariants?: "variants" extends keyof Composers[K]
               ? {
-                  [Name in keyof Composers[K]["variants"]]?: keyof Composers[K]["variants"][Name];
+                  [Name in keyof Composers[K]["variants"]]?: Util.Widen<
+                    keyof Composers[K]["variants"][Name]
+                  >;
                 }
               : never;
 
@@ -115,7 +117,9 @@ export interface ClassedProxyFunctionType<
             variants?: Variants;
             defaultVariants?: "variants" extends keyof Composers[K]
               ? {
-                  [Name in keyof Composers[K]["variants"]]?: keyof Composers[K]["variants"][Name];
+                  [Name in keyof Composers[K]["variants"]]?: Util.Widen<
+                    keyof Composers[K]["variants"][Name]
+                  >;
                 }
               : never;
 

--- a/packages/react/test/classed.spec.tsx
+++ b/packages/react/test/classed.spec.tsx
@@ -132,6 +132,40 @@ describe("Classed with Variants", () => {
 
     expect(screen.getByTestId("btn")).toHaveClass("border-2 border-gray-500");
   });
+
+  it("Should handle numerical variants", () => {
+    const Button = classed("button", {
+      variants: {
+        size: {
+          1: "text-xs",
+          2: "text-sm",
+          3: "text-base",
+          "4": "text-lg",
+        },
+      },
+    });
+
+    const Button2 = classed("button", {
+      variants: {
+        size: {
+          1: "text-xs",
+          2: "text-sm",
+          3: "text-base",
+        },
+      },
+
+      defaultVariants: {
+        size: "3",
+      },
+    });
+
+    render(<Button size={"4"} data-testid="btn" />);
+
+    expect(screen.getByTestId("btn")).toHaveClass("text-lg");
+
+    render(<Button2 data-testid="btn2" />);
+    expect(screen.getByTestId("btn2")).toHaveClass("text-base");
+  });
 });
 
 describe("Composition", () => {


### PR DESCRIPTION
Fix numeric variants so that `type V = 1` becomes `type V = Union<1 | "1">`