### PR TITLE
perf(react): switch to es2018 build target

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,8 +15,8 @@
     "types": "./dist/index.d.ts"
   },
   "scripts": {
-    "dev": "bunchee ./index.ts --watch",
-    "build": "bunchee ./index.ts",
+    "dev": "bunchee ./index.ts --watch --target es2018",
+    "build": "bunchee ./index.ts --target es2018",
     "rsc-compat": "node ./.task/rsc-compat.js",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
Switch SWC output to es2018. Code targets browsers after 2018 only, set your bundler (webpack/Vite) to ES5 to transpile to lower target.

BREAKING CHANGE: React library is no longer compatible with pre es2018 browsers. This was default for core lib