### PR TITLE
feat(react): add createClassed API to extend classed

### DIFF
--- a/.changeset/eight-clouds-watch.md
+++ b/.changeset/eight-clouds-watch.md
@@ -1,0 +1,5 @@
+---
+"@tw-classed/react": minor
+---
+
+Add createClassed API to extend the classed function with additional functionality. Currently only "merger" prop is supported

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "docs": "2.0.8",
+    "@tw-classed/core": "1.2.5",
+    "@tw-classed/react": "1.2.5"
+  },
+  "changesets": []
+}

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -1,4 +1,5 @@
 export { classedProxy as classed } from "./src/proxy";
+export { createClassed } from "./src/classed";
 
 export type {
   InferVariantProps,

--- a/packages/react/src/classed.tsx
+++ b/packages/react/src/classed.tsx
@@ -1,0 +1,98 @@
+import {
+  ClassNamesAndVariant,
+  mapPropsToVariantClass,
+  parseClassNames,
+  TW_VARS,
+  Variants,
+} from "@tw-classed/core";
+import { forwardRef, useMemo } from "react";
+import {
+  AnyComponent,
+  ClassedComponentType,
+  ClassedFunctionProxy,
+} from "./types";
+import { isClassedComponent, COMPONENT_SYMBOL } from "./utility/unique";
+
+const cx = (...args: string[]) => args.filter(Boolean).join(" ");
+
+export const internalClassed = <
+  T extends keyof JSX.IntrinsicElements | AnyComponent,
+  V extends Variants = {}
+>(
+  elementType: T,
+  classNames: ClassNamesAndVariant<{}>[],
+  { merger = cx }: ClassedConfig = {}
+) => {
+  const { className, variants, defaultVariants, compoundVariants } =
+    parseClassNames(classNames);
+  const Comp = forwardRef(
+    ({ as, className: cName, ...props }: any, forwardedRef: any) => {
+      const Component = isClassedComponent(elementType)
+        ? elementType
+        : as || elementType;
+
+      // Map props variant to className
+      const variantClassNames = useMemo(() => {
+        return mapPropsToVariantClass(
+          { variants, defaultVariants, compoundVariants },
+          props,
+          true
+        );
+      }, [props]);
+
+      const merged = useMemo(
+        () => merger(className, cName, variantClassNames),
+        [className, cName, variantClassNames]
+      );
+
+      return (
+        <Component
+          className={merged}
+          {...props}
+          as={isClassedComponent(elementType) ? as : undefined}
+          ref={forwardedRef}
+        />
+      );
+    }
+  ) as unknown as ClassedComponentType<T, V>; // Add variant types
+
+  Comp.displayName = `TwComponent(${elementType.toString()})`;
+  // Set variables to check if component is classed
+  Reflect.set(Comp, TW_VARS, {
+    className,
+    variants,
+    defaultVariants,
+  });
+
+  Reflect.set(Comp, COMPONENT_SYMBOL, true);
+
+  return Comp;
+};
+
+export interface ClassedConfig {
+  merger?: (...args: string[]) => any;
+}
+
+export interface CreateClassedType {
+  (config?: ClassedConfig): {
+    classed: ClassedFunctionProxy;
+  };
+}
+
+export const createClassed = ((config: any) => {
+  const classedWithConfig = (elementType: any, ...args: any[]) => {
+    return internalClassed(elementType, args, config);
+  };
+
+  const classedProxy = new Proxy(classedWithConfig, {
+    get: (_, type) => {
+      return function (this: unknown, ...args: any[]) {
+        return classedWithConfig.apply(this, [type as any, ...args]);
+      };
+    },
+  });
+
+  return {
+    classed: classedProxy,
+  };
+}) as CreateClassedType;

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,65 +1,15 @@
-import { forwardRef, useMemo } from "react";
-import {
-  parseClassNames,
-  TW_VARS,
-  mapPropsToVariantClass,
-} from "@tw-classed/core";
 import type { Variants, ClassNamesAndVariant } from "@tw-classed/core";
 
-import type {
-  AnyComponent,
-  ClassedComponentType,
-  ClassedFunctionType,
-} from "./types";
-import { COMPONENT_SYMBOL, isClassedComponent } from "./utility/unique";
+import type { AnyComponent, ClassedFunctionType } from "./types";
+import { internalClassed } from "./classed";
 
 export * from "./types";
-
-const cx = (...args: string[]) => args.filter(Boolean).join(" ");
 
 function classed<
   T extends keyof JSX.IntrinsicElements | AnyComponent,
   V extends Variants = {}
 >(elementType: T, ...classNames: ClassNamesAndVariant<V>[]) {
-  const { className, variants, defaultVariants, compoundVariants } =
-    parseClassNames(classNames);
-  const Comp = forwardRef(
-    ({ as, className: cName, ...props }: any, forwardedRef: any) => {
-      const Component = isClassedComponent(elementType)
-        ? elementType
-        : as || elementType;
-
-      // Map props variant to className
-      const variantClassNames = useMemo(() => {
-        return mapPropsToVariantClass(
-          { variants, defaultVariants, compoundVariants },
-          props,
-          true
-        );
-      }, [props]);
-
-      return (
-        <Component
-          className={cx(className, cName, variantClassNames)}
-          {...props}
-          as={isClassedComponent(elementType) ? as : undefined}
-          ref={forwardedRef}
-        />
-      );
-    }
-  ) as unknown as ClassedComponentType<T, V>; // Add variant types
-
-  Comp.displayName = `TwComponent(${elementType.toString()})`;
-  // Set variables to check if component is classed
-  Reflect.set(Comp, TW_VARS, {
-    className,
-    variants,
-    defaultVariants,
-  });
-
-  Reflect.set(Comp, COMPONENT_SYMBOL, true);
-
-  return Comp;
+  return internalClassed(elementType, classNames);
 }
 
 export default classed as ClassedFunctionType;

--- a/packages/react/src/proxy.tsx
+++ b/packages/react/src/proxy.tsx
@@ -1,9 +1,4 @@
-import classed, { ClassedFunctionProxy } from "./index";
+import { createClassed } from "./classed";
+import { ClassedFunctionProxy } from "./types";
 
-export const classedProxy = new Proxy(classed, {
-  get: (_, type) => {
-    return function (this: unknown, ...args: any[]) {
-      return classed.apply(this, [type as any, ...args]);
-    };
-  },
-}) as ClassedFunctionProxy;
+export const classedProxy = createClassed().classed as ClassedFunctionProxy;

--- a/packages/react/test/createClassed.spec.tsx
+++ b/packages/react/test/createClassed.spec.tsx
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { createClassed } from "../src/classed";
+import { render, screen } from "./test.utils";
+import React from "react";
+
+describe("CreateClassed", () => {
+  it("should work", () => {
+    const { classed } = createClassed();
+
+    expect(classed).toBeDefined();
+
+    const Comp = classed("div", {
+      base: "bg-red-500",
+      variants: {
+        color: {
+          red: "bg-red-500",
+          blue: "bg-blue-500",
+        },
+      },
+      defaultVariants: {
+        color: "red",
+      },
+    });
+
+    expect(Comp).toBeDefined();
+
+    render(<Comp data-testid="a" />);
+
+    expect(screen.getByTestId("a")).toHaveClass("bg-red-500");
+
+    render(<Comp data-testid="b" color="blue" />);
+    expect(screen.getByTestId("b")).toHaveClass("bg-blue-500");
+  });
+
+  it("should work with proxy", () => {
+    const { classed } = createClassed();
+
+    const Comp = classed.div({
+      base: "bg-red-500",
+      variants: {
+        color: {
+          red: "bg-red-500",
+          blue: "bg-blue-500",
+        },
+      },
+      defaultVariants: {
+        color: "red",
+      },
+    });
+
+    expect(Comp).toBeDefined();
+
+    render(<Comp data-testid="a" />);
+
+    expect(screen.getByTestId("a")).toHaveClass("bg-red-500");
+
+    render(<Comp data-testid="b" color="blue" />);
+    expect(screen.getByTestId("b")).toHaveClass("bg-blue-500");
+  });
+});
+
+describe("createClassed with config", () => {
+  it("Should accept a custom merger", () => {
+    const merger = (...args: string[]) => args.join("$_TEST_$"); // Test symbol to see if merger is works
+    const { classed } = createClassed({ merger });
+
+    const Comp = classed("div", {
+      base: "bg-red-500",
+      variants: {
+        color: {
+          red: "bg-red-500",
+          blue: "bg-blue-500",
+        },
+      },
+      defaultVariants: {
+        color: "red",
+      },
+    });
+
+    expect(Comp).toBeDefined();
+
+    render(<Comp data-testid="a" />);
+
+    const className = screen.getByTestId("a").className;
+
+    expect(className).toContain("$_TEST_$");
+
+    const classNameSplit = className.split("$_TEST_$");
+
+    expect(classNameSplit).toHaveLength(3);
+    expect(classNameSplit).toContain("bg-red-500");
+  });
+
+  it("Should accept an advanced merger", () => {
+    const merger = (...args: string[]) => {
+      const cache = new Map<string, string>();
+      const result = args.reduce((acc, arg) => {
+        if (cache.has(arg)) {
+          return acc;
+        }
+
+        cache.set(arg, arg);
+
+        return acc + " " + arg;
+      }, "");
+
+      return result.trim();
+    };
+
+    const { classed } = createClassed({ merger });
+
+    const Comp = classed("div", {
+      base: "bg-red-500",
+      variants: {
+        color: {
+          red: "bg-red-500",
+          blue: "bg-blue-500",
+        },
+      },
+
+      defaultVariants: {
+        color: "red",
+      },
+    });
+
+    expect(Comp).toBeDefined();
+
+    render(<Comp data-testid="a" />);
+
+    const className = screen.getByTestId("a").className;
+
+    expect(className).toContain("bg-red-500");
+
+    // Should only have one bg-red-500
+    expect(className.split("bg-red-500")).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Adds an optional createClassed API to extend classed, currently only "merger" prop is supported.