### PR TITLE
Export DerivedComponentType to handle polymorphic as prop usage 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ coverage/tmp/**
 .pnpm-store
 
 .trace_dir
+
+tsconfig.test.tsbuildinfo

--- a/apps/docs/pages/docs/typescript.mdx
+++ b/apps/docs/pages/docs/typescript.mdx
@@ -15,6 +15,7 @@ import type * as Classed from "@tw-classed/react";
 These include:
 
 - `Classed.ClassedComponentType` - the type of a classed component
+- `Classed.DerivedComponentType` The type of a derived component. (Removing the `as` prop from the base component)
 - `Classed.InferVariantProps` Infers the variant props of a set of variants (internal but exported for convenience)
 - `Classed.VariantProps` Infers the variant props of a component
 - `Classed.Variants` The legal variants of a component (use to type an external variant object)
@@ -39,6 +40,48 @@ type ButtonVariants = Classed.VariantProps<typeof Button>;
 // }
 
 export type ButtonProps = React.ComponentProps<typeof Button>; // This of course works as expected
+```
+
+### Creating a derived component
+
+Sometimes you might have to extend a component with React logic. You can do this by creating a derived component.
+
+For Typescript to work correctly with the `as` prop you need to override the component's type as `DerivedComponentType` type. This internally removes the `as` prop from the base component.
+
+```tsx
+import { DerivedComponentType } from "@tw-classed/react";
+import { forwardRef } from "react";
+import { classed } from "@tw-classed/react";
+
+const BaseButton = classed("button", "px-2 py-4", {
+  variants: {
+    color: {
+      blue: "bg-blue-500",
+      red: "bg-red-500",
+    },
+  },
+});
+
+type BaseButtonProps = React.ComponentProps<typeof BaseButton> & {
+  icon?: React.ReactNode; // Add an icon prop
+};
+
+const Button = forwardRef<HTMLButtonElement, BaseButtonProps>(
+  ({ icon, ...props }, ref) => {
+    return (
+      <BaseButton {...props} ref={ref}>
+        {icon && <span className="mr-2">{icon}</span>}
+        {props.children}
+      </BaseButton>
+    );
+  }
+) as DerivedComponentType<typeof BaseButton, BaseButtonProps>;
+
+() => (
+  <Button color="blue" as="a" href="/">
+    Click me
+  </Button>
+);
 ```
 
 ### Typescript 4.9 and above (satisfies api)

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -5,4 +5,5 @@ export type {
   InferVariantProps,
   ClassedComponentType,
   VariantProps,
+  DerivedComponentType,
 } from "./src/types";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,6 +22,7 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit --project ./tsconfig.test.json",
     "prepublishOnly": "cd ../../ && turbo run build test --filter=@tw-classed/react"
   },
   "keywords": [],

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -19,6 +19,12 @@ export interface ClassedComponentType<
   [$$ClassedComponentVariants]: TComposedVariants;
 }
 
+export type DerivedComponentType<
+  Type extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+  Props extends {} = {},
+  TComposedVariants extends {} = {}
+> = ClassedComponentType<Type, Omit<Props, "as">, TComposedVariants>;
+
 /** Unique symbol used to reference the props of a Classed Component. */
 export declare const $$ClassedComponentProps: unique symbol;
 export type $$ClassedComponentProps = typeof $$ClassedComponentProps;

--- a/packages/react/test/classed.spec.tsx
+++ b/packages/react/test/classed.spec.tsx
@@ -227,7 +227,7 @@ describe("Composition", () => {
     }: React.ComponentProps<typeof BasicButton>) => (
       <BasicButton loading={loading} {...props}>
         <ButtonContent
-          data-testid={props["data-innertestid"]}
+          data-testid={(props as any)["data-innertestid"]}
           loading={loading}
         >
           {children}

--- a/packages/react/test/types.spec.tsx
+++ b/packages/react/test/types.spec.tsx
@@ -1,0 +1,69 @@
+import React, { forwardRef } from "react";
+import { assertType, expectTypeOf } from "vitest";
+import { classed } from "../index";
+import {
+  ClassedComponentType,
+  DerivedComponentType,
+  VariantProps,
+} from "../src/types";
+
+test("It Should create a JSX Element", () => {
+  const Button = classed("button", {
+    variants: {
+      size: {
+        sm: "text-sm",
+        md: "text-md",
+        lg: "text-lg",
+      },
+    },
+  });
+
+  const button = <Button size="sm" />;
+
+  expectTypeOf(button).toMatchTypeOf<JSX.Element>();
+});
+
+test("DerivedComponentType -> Should successfully infer the type of the component", () => {
+  const InnerButton = classed("button", {
+    variants: {
+      size: {
+        sm: "text-sm",
+        md: "text-md",
+      },
+    },
+  });
+
+  interface ButtonProps extends React.ComponentProps<typeof InnerButton> {
+    icon?: React.ReactNode;
+  }
+
+  type Variants = VariantProps<typeof InnerButton>;
+
+  const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+    ({ icon, ...rest }, ref) => {
+      return (
+        <InnerButton ref={ref} {...rest}>
+          {icon}
+        </InnerButton>
+      );
+    }
+  ) as DerivedComponentType<typeof InnerButton, ButtonProps>;
+
+  const button = <Button as="a" href="/" size="sm" />;
+
+  expectTypeOf(button).toMatchTypeOf<JSX.Element>();
+
+  assertType<ClassedComponentType<typeof InnerButton, ButtonProps>>(Button);
+
+  // @ts-expect-error - Value of type 'number' is not assignable to type '"sm" | "md"'
+  assertType(<Button size={1} />);
+
+  // @ts-expect-error - Value of type 'xl' is not assignable to type '"sm" | "md"'
+  assertType(<Button size="xl" />);
+
+  assertType<true>(
+    expectTypeOf<Variants["size"]>().toEqualTypeOf<
+      React.ComponentProps<typeof Button>["size"]
+    >()
+  );
+});

--- a/packages/react/tsconfig.test.json
+++ b/packages/react/tsconfig.test.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "downlevelIteration": true,
+    "types": ["react", "react-dom"]
+  },
+  "include": ["test"],
+  "exclude": ["node_modules"]
+}

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -3,17 +3,10 @@
 
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
-import { resolve } from "path";
-import dts from "vite-plugin-dts";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    react(),
-    dts({
-      insertTypesEntry: true,
-    }),
-  ],
+  plugins: [react()],
   build: {
     lib: {
       entry: ["./src/index.tsx"],
@@ -36,5 +29,8 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: "./test/setup.ts",
+    typecheck: {
+      include: ["./test/**/*.{ts,tsx}"],
+    },
   },
 });

--- a/turbo.json
+++ b/turbo.json
@@ -7,8 +7,11 @@
     "lint": {
       "outputs": []
     },
+    "typecheck": {
+      "outputs": ["tsconfig.test.tsbuildinfo"]
+    },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "^typecheck"],
       "outputs": ["coverage/**", "dist/**", ".next/**"]
     },
     "test:coverage": {


### PR DESCRIPTION
x-ref: #56 

Exports DerivedComponentType in order to allow for deriving a classed component with react specific functionality