### PR TITLE
122 feature request default props when creating components

### DIFF
--- a/.changeset/pink-dolls-confess.md
+++ b/.changeset/pink-dolls-confess.md
@@ -1,0 +1,19 @@
+---
+"@tw-classed/react": minor
+"@tw-classed/core": minor
+---
+
+- (Feat): Add support for defaultProps in React api
+  Components can now have default props in the React api
+
+```tsx
+const Button = classed.button({
+  defaultProps: {
+    someProp: "someValue",
+  },
+});
+```
+
+This change is considered unstable, for now defaultProps will not populate when using composition nor affect variants or classname generation.
+
+- (Fix): Data attributes are now correctly generated for composition

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -21,6 +21,7 @@ export const parseClassNames = <TVariants extends Variants>(
   >;
   let compoundVariants = [] as Record<string, any>[];
   let dataAttributes = new Set<string>();
+  let defaultProps: Record<string, unknown> = {};
 
   for (const className of classNames) {
     if (!className) continue;
@@ -35,18 +36,23 @@ export const parseClassNames = <TVariants extends Variants>(
         ? Reflect.get<VariantConfig<TVariants>, symbol>(className, TW_VARS)
         : (className as VariantConfig<TVariants>);
 
-      record.variants && Object.assign(variantObj, record.variants);
-      record.defaultVariants &&
-        Object.assign(defaultVariants, record.defaultVariants);
-      record.compoundVariants &&
-        record.compoundVariants.forEach((cv) => compoundVariants.push(cv));
-      record.className && stringClassNames.push(record.className);
-      record.base && stringClassNames.push(record.base);
+      if (record.variants) Object.assign(variantObj, record.variants);
 
-      record.dataAttributes &&
+      if (record.defaultVariants)
+        Object.assign(defaultVariants, record.defaultVariants);
+
+      if (record.compoundVariants)
+        record.compoundVariants.forEach((cv) => compoundVariants.push(cv));
+
+      if (record.className) stringClassNames.push(record.className);
+      if (record.base) stringClassNames.push(record.base);
+
+      if (record.dataAttributes)
         record.dataAttributes.forEach((name) => {
           dataAttributes.add(name);
         });
+
+      if (record.defaultProps) Object.assign(defaultProps, record.defaultProps);
     }
   }
 
@@ -56,6 +62,7 @@ export const parseClassNames = <TVariants extends Variants>(
     defaultVariants,
     compoundVariants,
     dataAttributes: Array.from(dataAttributes),
+    defaultProps,
   };
 };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,7 +5,7 @@ export type Variants = Record<string, Variant>;
 export type BooleanVariant = Record<"true", string>;
 
 /**
- * @deprecated
+ * @internal
  */
 export type VariantConfig<V extends Variants> = {
   variants?: V;
@@ -15,8 +15,8 @@ export type VariantConfig<V extends Variants> = {
     [K in keyof V]: keyof V[K];
   }>;
   compoundVariants: Record<string, any>[];
-  // TODO: Type this properly
   dataAttributes?: string[];
+  defaultProps?: Record<string, unknown>;
 };
 
 export type ClassNamesAndVariant<V extends Variants> =

--- a/packages/react/src/classed.tsx
+++ b/packages/react/src/classed.tsx
@@ -16,7 +16,8 @@ import {
 } from "./types";
 import { isClassedComponent, COMPONENT_SYMBOL } from "./utility/unique";
 
-export const cx = (...args: string[]): string => args.filter((v) => !!v && typeof v === "string").join(" ");
+export const cx = (...args: string[]): string =>
+  args.filter((v) => !!v && typeof v === "string").join(" ");
 
 export const internalClassed = <
   T extends keyof JSX.IntrinsicElements | AnyComponent,
@@ -31,9 +32,15 @@ export const internalClassed = <
   if (isClassed) {
     toParse.unshift(elementType as any);
   }
-  const { className, variants, defaultVariants, compoundVariants, dataAttributes } =
-    parseClassNames(toParse);
-    
+  const {
+    className,
+    variants,
+    defaultVariants,
+    compoundVariants,
+    dataAttributes,
+    defaultProps,
+  } = parseClassNames(toParse);
+
   const Comp = forwardRef(
     ({ as, className: cName, ...props }: any, forwardedRef: any) => {
       const Component = isClassed
@@ -42,20 +49,23 @@ export const internalClassed = <
         ? elementType
         : as || elementType;
 
-      const dataAttributeProps = getDataAttributes({
-        props,
-        dataAttributes,
-        variants,
-        defaultVariants
-      })
-
       // Map props variant to className
-      const variantClassNames = useMemo(() => {
-        return mapPropsToVariantClass(
-          { variants, defaultVariants, compoundVariants },
+      const [variantClassNames, dataAttributeProps] = useMemo(() => {
+        const dataAttributeProps = getDataAttributes({
           props,
-          true
-        );
+          dataAttributes,
+          variants,
+          defaultVariants,
+        });
+
+        return [
+          mapPropsToVariantClass(
+            { variants, defaultVariants, compoundVariants },
+            props,
+            true
+          ),
+          dataAttributeProps,
+        ] as const;
       }, [props]);
 
       const merged = useMemo(
@@ -71,6 +81,7 @@ export const internalClassed = <
             ? defaultVariants
             : {})}
           {...dataAttributeProps}
+          {...defaultProps}
           as={isClassed ? as : undefined}
           ref={forwardedRef}
         />
@@ -89,6 +100,7 @@ export const internalClassed = <
     variants,
     defaultVariants,
     compoundVariants,
+    dataAttributes,
   });
 
   Reflect.set(Comp, COMPONENT_SYMBOL, true);

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -108,6 +108,7 @@ export interface ClassedFunctionType {
           base?: string;
           variants?: { [name: string]: unknown };
           defaultVariants?: { [name: string]: unknown };
+          defaultProps?: Record<string, any>;
         }
     )[]
   >(
@@ -143,6 +144,8 @@ export interface ClassedFunctionType {
             dataAttributes?: "variants" extends keyof Composers[K]
               ? Array<keyof Composers[K]["variants"]>
               : Array<string>;
+
+            defaultProps?: Record<string, any>;
           };
     }
   ): ClassedComponentType<
@@ -166,6 +169,7 @@ export interface ClassedProxyFunctionType<
           base?: string;
           variants?: { [name: string]: unknown };
           defaultVariants?: { [name: string]: unknown };
+          defaultProps?: Record<string, any>;
         }
     )[]
   >(
@@ -200,6 +204,8 @@ export interface ClassedProxyFunctionType<
             dataAttributes?: "variants" extends keyof Composers[K]
               ? Array<keyof Composers[K]["variants"]>
               : Array<string>;
+
+            defaultProps?: Record<string, any>;
           };
     }
   ): ClassedComponentType<

--- a/packages/react/test/classed.spec.tsx
+++ b/packages/react/test/classed.spec.tsx
@@ -55,7 +55,7 @@ describe("Classed", () => {
 
     expect(screen.getByTestId("btn")).toBeDisabled();
     expect(screen.getByTestId("btn")).toHaveAttribute("data-cy", "test");
-  })
+  });
 });
 
 describe("Classed with Variants", () => {
@@ -298,6 +298,18 @@ describe("Classed with Variants", () => {
 
     expectTypeOf<Button3Extract["dataAttributes"]>().toMatchTypeOf<"size"[]>();
   });
+
+  it("Should render default props on component", () => {
+    const Button = classed("button", {
+      defaultProps: {
+        disabled: true,
+      },
+    });
+
+    render(<Button data-testid="btn" />);
+
+    expect(screen.getByTestId("btn")).toBeDisabled();
+  });
 });
 
 describe("Composition", () => {
@@ -428,6 +440,31 @@ describe("Composition", () => {
         Click me
       </Button4>
     );
+  });
+
+  it("Should correctly render data-attributes when composed", () => {
+    const Button = classed("button", {
+      variants: { loading: { true: "animate-pulse" } },
+      dataAttributes: ["loading"],
+    });
+
+    const Button2 = classed(Button, {
+      variants: { color: { blue: "bg-blue-100" } },
+      dataAttributes: ["color"],
+    });
+
+    render(<Button2 color="blue" data-testid="btn" loading />);
+
+    expect(screen.getByTestId("btn")).toHaveClass("animate-pulse bg-blue-100");
+    expect(screen.getByTestId("btn")).toHaveAttribute("data-color", "blue");
+    expect(screen.getByTestId("btn")).toHaveAttribute("data-loading");
+
+    const Button3 = classed.button(Button);
+
+    render(<Button3 color="blue" data-testid="btn3" loading />);
+
+    expect(screen.getByTestId("btn3")).toHaveClass("animate-pulse");
+    expect(screen.getByTestId("btn3")).toHaveAttribute("data-loading");
   });
 });
 

--- a/packages/react/tsconfig.test.json
+++ b/packages/react/tsconfig.test.json
@@ -17,6 +17,6 @@
     "downlevelIteration": true,
     "types": ["react", "react-dom"]
   },
-  "include": ["test/**"],
+  "include": ["./test/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This PR adds a small bugfixes and a convenience api for default props

- (Feat): Add support for defaultProps in React api
  Components can now have default props in the React api
- (Fix): Data attributes are now correctly generated for composition

fixes: #122 
fixes: #123 