### PR TITLE
fix html output of data-variant example

### DIFF
--- a/apps/docs/pages/docs/data-variants.mdx
+++ b/apps/docs/pages/docs/data-variants.mdx
@@ -88,8 +88,7 @@ Output:
 ```html
 <button class="p-4 group bg-white text-slate-900" data-color="light">
   <svg
-    class="animate-spin rounded-full h-8 w-8 text-slate-900"
-    data-group-data="[color=dark]:text-white"
+    class="animate-spin rounded-full h-8 w-8 text-slate-900 group-data-[color=dark]:text-white"
   >
     ...
   </svg>


### PR DESCRIPTION
I guess the svg won't have an attribute `data-group-data="[color=dark]:text-white"` but the class `group-data-[color=dark]:text-white`, right?